### PR TITLE
Fix anki.po:643: 'msgid' and 'msgstr' entries do not both end with '\n'

### DIFF
--- a/desktop/de/anki.po
+++ b/desktop/de/anki.po
@@ -1,4 +1,4 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: anki\n"
@@ -639,7 +639,7 @@ msgid ""
 "\n"
 "<p>When you've discovered the add-on that is causing the problem, please report the issue on the <a href=\"https://help.ankiweb.net/discussions/add-ons/\">add-ons section</a> of our support site.\n"
 "\n"
-"<p>Debug info:</p>\n"
+"<p>Debug info:</p>"
 msgstr ""
 "a<h1>Fehler</h1>\n"
 "\n"


### PR DESCRIPTION
https://anki.tenderapp.com/discussions/beta-testing/1813-ankipo643-msgid-and-msgstr-entries-do-not-both-end-with-n