### PR TITLE
Added missing UTF-8 enconding to open

### DIFF
--- a/check-po-files.py
+++ b/check-po-files.py
@@ -49,7 +49,7 @@ def fix_po(path):
     problems = []
     strs = []
 
-    for line in open(path):
+    for line in open(path, encoding="UTF-8"):
         lines.append(line)
 
         # comment?


### PR DESCRIPTION
I am trying to build this project, but I am getting this error in the middle of the building:
```
Traceback (most recent call last):
  File "check-po-files.py", line 108, in <module>
    problems += fix_po(path)
  File "check-po-files.py", line 52, in fix_po
    for line in open(path):
  File "F:\Python\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 726: character maps to <undefined>
make[1]: *** [Makefile:33: .build/i18n] Error 1
```

After adding `encoding="UTF-8"`, the error was fixed.