### PR TITLE
Fixed translations on desktop/hu/anki.po causing

### DIFF
--- a/desktop/hu/anki.po
+++ b/desktop/hu/anki.po
@@ -1,4 +1,4 @@
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: anki\n"
@@ -857,7 +857,7 @@ msgstr ""
 "Nem sikerült betölteni egy telepített kiegészítőt. Ha a probléma továbbra is fennáll, lépjen az Eszközök - Kiegészítők menübe, és tiltsa le vagy törölje a kiegészítőt.\n"
 "\n"
 "Betöltéskor '%(name)s':\n"
-"%(traceback)s"
+"%(traceback)s\n"
 
 #: qt/aqt/errors.py:111
 msgid ""
@@ -946,7 +946,7 @@ msgid ""
 msgstr ""
 "Anki nem tudta megnyitni a gyűjteményfájlt. Ha a számítógép újraindítása után továbbra is problémák merülnek fel, kérjük, használja a Biztonsági mentés megnyitása gombot a profilkezelőben.\n"
 "\n"
-"Hibakeresési információ:"
+"Hibakeresési információ:\n"
 
 #: qt/aqt/sync.py:107
 msgid "AnkiWeb ID or password was incorrect; please try again."


### PR DESCRIPTION
Building 'po/desktop/hu/anki.po'
<stdin>:728: 'msgid' and 'msgstr' entries do not both end with '\n'
<stdin>:810: 'msgid' and 'msgstr' entries do not both end with '\n'
F:\Cygwin\bin\msgfmt.exe: found 2 fatal errors
make[1]: *** [Makefile:31: .build/i18n] Error 1

I used the change from https://github.com/ankitects/anki/pull/463 to track down where the problem was.

I see today/yesterday someone pushed hu translations, breaking things. Why the tests are not failing?