### PR TITLE
Fix Anki `make check`

### DIFF
--- a/desktop/hu/anki.po
+++ b/desktop/hu/anki.po
@@ -857,7 +857,7 @@ msgstr ""
 "Nem sikerült betölteni egy telepített kiegészítőt. Ha a probléma továbbra is fennáll, lépjen az Eszközök - Kiegészítők menübe, és tiltsa le vagy törölje a kiegészítőt.\n"
 "\n"
 "Betöltéskor '%(name)s':\n"
-"%(traceback)s"
+"%(traceback)s\n"
 
 #: qt/aqt/errors.py:111
 msgid ""
@@ -946,7 +946,7 @@ msgid ""
 msgstr ""
 "Anki nem tudta megnyitni a gyűjteményfájlt. Ha a számítógép újraindítása után továbbra is problémák merülnek fel, kérjük, használja a Biztonsági mentés megnyitása gombot a profilkezelőben.\n"
 "\n"
-"Hibakeresési információ:"
+"Hibakeresési információ:\n"
 
 #: qt/aqt/sync.py:107
 msgid "AnkiWeb ID or password was incorrect; please try again."


### PR DESCRIPTION
This fixes the current failure on the main Anki repo when running `make check`:

```
 <stdin>:728: 'msgid' and 'msgstr' entries do not both end with '\n'
<stdin>:810: 'msgid' and 'msgstr' entries do not both end with '\n'
```