### PR TITLE
Created the special environment variable `SHELLFLAGS`

### DIFF
--- a/check-merge.sh
+++ b/check-merge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -eu -o pipefail ${SHELLFLAGS}
 
 for file in desktop/*/anki.po; do
   (msgmerge -q "$file" desktop/anki.pot | msgfmt - --output-file /dev/null) || (


### PR DESCRIPTION
This allows the user to easily debug installation errors by defining the environment variable `SHELLFLAGS=-x` before running anything. The flag `-x` will cause bash to print out every command it is running. This is vital to figure out how to make the GitHub Actions to work.

Also added by default the `-u` flag to all shell scripts. All `Makefile`s were already using it, then, I decided to normalize it and keep everybody using it. The `-u` flags causes the shell script to fail if it attempts to use a variable which is not defined. If a variable can be undefined, we need to explicitly say it by adding this before using it:
```shell
if [[ -z "${variablename+x}" ]]; then
    variablename=;
fi
```

This is part of the changes I used to setup the GitHub Actions for Windows. With this `SHELLFLAGS=-x` thing I was able to figure out how and why things where not working.